### PR TITLE
Add cython to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy==1.18.1
 scipy==1.4.1
 matplotlib==3.1.2
 dill==0.2.9
+cython
 scikit-learn==0.22
 sympy


### PR DESCRIPTION
Beim Aufrufen von `./configure` fehlte für scikit-learn das Cython Modul. Ist das nur bei mir so?
Hab das für alle Fälle mal in die requirements mit aufgenommen...